### PR TITLE
fix: Load .env file in update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,5 @@ After the initial deployment, you can use the `update.sh` script to deploy new c
     -   Pull the latest code.
     -   Install any new dependencies for the frontend and backend.
     -   Re-build the frontend.
-    -   Apply any new database migrations.
+    -   Apply any new database migrations (it will automatically load the credentials from `backend/.env`).
     -   Restart the backend server and Nginx.

--- a/update.sh
+++ b/update.sh
@@ -43,6 +43,17 @@ cd backend
 echo "Installing/updating backend dependencies..."
 npm install
 
+echo "Loading environment variables for Prisma..."
+if [ -f .env ]; then
+  # A safe way to load environment variables from .env file
+  set -o allexport
+  source .env
+  set +o allexport
+  echo ".env file loaded."
+else
+  echo "Warning: .env file not found. Prisma commands may fail if DATABASE_URL is not set."
+fi
+
 echo "Running any new database migrations..."
 npx prisma migrate deploy
 


### PR DESCRIPTION
This commit fixes a bug in the `update.sh` script where the `prisma migrate deploy` command would fail because the `DATABASE_URL` environment variable was not available in the `sudo` context.

The script now securely loads the `backend/.env` file before running the migration command, ensuring that Prisma has access to the necessary database credentials.